### PR TITLE
GRPH-4-CliWalletCoreDumpOnCtrlD -- Crash fix, crash happens because o…

### DIFF
--- a/include/fc/rpc/websocket_api.hpp
+++ b/include/fc/rpc/websocket_api.hpp
@@ -10,7 +10,7 @@ namespace fc { namespace rpc {
    class websocket_api_connection : public api_connection
    {
       public:
-         websocket_api_connection( fc::http::websocket_connection& c );
+         websocket_api_connection( const std::shared_ptr<fc::http::websocket_connection> &c );
          ~websocket_api_connection();
 
          virtual variant send_call(
@@ -29,7 +29,7 @@ namespace fc { namespace rpc {
             const std::string& message,
             bool send_message = true );
 
-         fc::http::websocket_connection&  _connection;
+         std::shared_ptr<fc::http::websocket_connection>  _connection;
          fc::rpc::state                   _rpc_state;
    };
 

--- a/src/rpc/websocket_api.cpp
+++ b/src/rpc/websocket_api.cpp
@@ -7,9 +7,10 @@ websocket_api_connection::~websocket_api_connection()
 {
 }
 
-websocket_api_connection::websocket_api_connection( fc::http::websocket_connection& c )
+websocket_api_connection::websocket_api_connection( const std::shared_ptr<fc::http::websocket_connection>& c )
    : _connection(c)
 {
+   FC_ASSERT( c );
    _rpc_state.add_method( "call", [this]( const variants& args ) -> variant
    {
       FC_ASSERT( args.size() == 3 && args[2].is_array() );
@@ -38,9 +39,9 @@ websocket_api_connection::websocket_api_connection( fc::http::websocket_connecti
       return this->receive_call( 0, method_name, args );
    } );
 
-   _connection.on_message_handler( [&]( const std::string& msg ){ on_message(msg,true); } );
-   _connection.on_http_handler( [&]( const std::string& msg ){ return on_message(msg,false); } );
-   _connection.closed.connect( [this](){ closed(); } );
+   _connection->on_message_handler( [&]( const std::string& msg ){ on_message(msg,true); } );
+   _connection->on_http_handler( [&]( const std::string& msg ){ return on_message(msg,false); } );
+   _connection->closed.connect( [this](){ closed(); } );
 }
 
 variant websocket_api_connection::send_call(
@@ -48,26 +49,37 @@ variant websocket_api_connection::send_call(
    string method_name,
    variants args /* = variants() */ )
 {
-   auto request = _rpc_state.start_remote_call(  "call", {api_id, std::move(method_name), std::move(args) } );
-   _connection.send_message( fc::json::to_string(request) );
-   return _rpc_state.wait_for_response( *request.id );
+   if( _connection )
+   {
+      auto request = _rpc_state.start_remote_call(  "call", {api_id, std::move(method_name), std::move(args) } );
+      _connection->send_message( fc::json::to_string(request) );
+      return _rpc_state.wait_for_response( *request.id );
+   }
+   return variant();
 }
 
 variant websocket_api_connection::send_callback(
    uint64_t callback_id,
    variants args /* = variants() */ )
 {
-   auto request = _rpc_state.start_remote_call( "callback", {callback_id, std::move(args) } );
-   _connection.send_message( fc::json::to_string(request) );
-   return _rpc_state.wait_for_response( *request.id );
+   if( _connection )
+   {
+      auto request = _rpc_state.start_remote_call( "callback", {callback_id, std::move(args) } );
+      _connection->send_message( fc::json::to_string(request) );
+      return _rpc_state.wait_for_response( *request.id );
+   }
+   return variant();
 }
 
 void websocket_api_connection::send_notice(
    uint64_t callback_id,
    variants args /* = variants() */ )
 {
-   fc::rpc::request req{ optional<uint64_t>(), "notice", {callback_id, std::move(args)}};
-   _connection.send_message( fc::json::to_string(req) );
+   if( _connection )
+   {
+      fc::rpc::request req{ optional<uint64_t>(), "notice", {callback_id, std::move(args)}};
+      _connection->send_message( fc::json::to_string(req) );
+   }
 }
 
 std::string websocket_api_connection::on_message(
@@ -88,8 +100,8 @@ std::string websocket_api_connection::on_message(
             if( call.id )
             {
                auto reply = fc::json::to_string( response( *call.id, result ) );
-               if( send_message )
-                  _connection.send_message( reply );
+               if( send_message && _connection )
+                  _connection->send_message( reply );
                return reply;
             }
          }
@@ -103,8 +115,8 @@ std::string websocket_api_connection::on_message(
          if( optexcept ) {
 
                auto reply = fc::json::to_string( response( *call.id,  error_object{ 1, optexcept->to_detail_string(), fc::variant(*optexcept)}  ) );
-               if( send_message )
-                  _connection.send_message( reply );
+               if( send_message && _connection )
+                  _connection->send_message( reply );
 
                return reply;
          }

--- a/tests/api.cpp
+++ b/tests/api.cpp
@@ -59,7 +59,7 @@ int main( int argc, char** argv )
 
       fc::http::websocket_server server;
       server.on_connection([&]( const websocket_connection_ptr& c ){
-               auto wsc = std::make_shared<websocket_api_connection>(*c);
+               auto wsc = std::make_shared<websocket_api_connection>(c);
                auto login = std::make_shared<login_api>();
                login->calc = calc_api;
                wsc->register_api(fc::api<login_api>(login));
@@ -74,7 +74,7 @@ int main( int argc, char** argv )
          try { 
             fc::http::websocket_client client;
             auto con  = client.connect( "ws://localhost:8090" );
-            auto apic = std::make_shared<websocket_api_connection>(*con);
+            auto apic = std::make_shared<websocket_api_connection>(con);
             auto remote_login_api = apic->get_remote_api<login_api>();
             auto remote_calc = remote_login_api->get_calc();
             remote_calc->on_result( []( uint32_t r ) { elog( "callback result ${r}", ("r",r) ); } );


### PR DESCRIPTION
…f use of destroyed connection object in websocket_api_connection, so making the connection shared_ptr to prevent it from destorying.