### PR TITLE
GRPH-46-AddQuitCommandToCliWallet - Add Quit command to CLI Wallet

### DIFF
--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -121,6 +121,11 @@ void cli::run()
       catch ( const fc::exception& e )
       {
          std::cout << e.to_detail_string() << "\n";
+
+         if (e.code() == fc::canceled_exception_code)
+         {
+            break;
+         }
       }
    }
 }


### PR DESCRIPTION
Add `quit` command to the CLI Wallet.
Required for https://github.com/peerplays-network/peerplays/pull/90.
Backport of the Bitshares https://github.com/bitshares/bitshares-fc/pull/63